### PR TITLE
Add Robinhood trading MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "robinhood-trading": {
+      "type": "http",
+      "url": "https://agent.robinhood.com/mcp/trading"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-scoped `.mcp.json` registering the **robinhood-trading** MCP server:

- Transport: `http`
- URL: `https://agent.robinhood.com/mcp/trading`

This is the checked-in equivalent of running:

```
claude mcp add robinhood-trading --transport http https://agent.robinhood.com/mcp/trading --scope project
```

With this file in the repo root, Claude Code sessions opened in this repository will automatically discover the server (each user approves project-scoped servers on first use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wv6yegMhnruqdX9ZC7Ewuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wv6yegMhnruqdX9ZC7Ewuh)_